### PR TITLE
CSS to put things in clearer (green) boxes + fix attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Next steps
 - support multiple xapi instances
 - support other services based on bbox queries (OSM History, OWL, ...)
 - set maximum bbox for a service
-- show only the current map attribution
 - list of predefined bboxs
 
 Description

--- a/css/common.css
+++ b/css/common.css
@@ -6,8 +6,8 @@ body {
   font-family: Arial,sans-serif;
   color: #000;
   background-color: #fff;
-  margin: 0px;
-  padding: 0px;
+ /* margin: 0px;
+  padding: 0px;*/
 }
 
 /* Rules for links */
@@ -353,8 +353,9 @@ hr {
   bottom: 0px;
 }
 
-.olControlAttribution {
-  display: none !important;
+div.olControlAttribution {
+   font-size: 0.6em;
+   bottom: 3px;
 }
 
 #permalink {

--- a/css/xapi.css
+++ b/css/xapi.css
@@ -1,22 +1,55 @@
 /* Custom CSS for the XAPI page */
 * {position:relative;}
-
+h1#title {
+	margin:2px;
+}
 #bboxmap {
     width: 512px;
     height: 256px;
     margin: 0;
     border: solid 1px #ddd;
+    background-color:#eee;
 }
-#attribution{
-    display: block;
-    font-size:x-small;
+
+.filter_box_content {
+	background-color:#eaf5ea;
+	padding:10px;
+	margin-bottom:10px;
 }
+.filter_box_top {
+	font-weight:bold;
+	background-color:#E0EEE0;
+	padding:3px;
+	margin-top:10px;
+}
+
+#mapcontrol  {
+	padding:4px;
+}
+#mapcontrol label, #mapcontrol input {
+	cursor:pointer;
+}
+
+#xapiurl {
+	background-color:#FFFFAA;
+	font-weight:bold;
+	padding:10px;
+	margin:10px;
+}
+#results_outer {
+	font-family: Courier New, Courier, monospace;
+	background:WHITE;
+	border:1px solid GREY;
+	padding:2px 10px 2px 10px;
+}
+
+
 
 /*input { font: 1em Verdana, Arial, sans serif; border:none;}*/
 
-input[type='text'] { font: 0.9em Verdana, Arial, sans serif; border:none; margin: 1px; background:#eee; opacity: 0.8; }
+input[type='text'] { font: 0.9em Verdana, Arial, sans serif; border:none; margin: 1px; background:WHITE; opacity: 0.8; }
 input[type='text']:hover { border: 1px solid #888; color: #FF9200; margin: 0px; }
-input[type='text']:focus { background: #FFCA00; border: 1px solid #000; color: #000; margin: 0px; }
+input[type='text']:focus { background: #FFFFAA; border: 1px solid #000; color: #000; margin: 0px; }
 
 label.bbox { font-family:sans-serif; font-size:xx-small; font-weight:bold; display: block;}
 input.bbox { width:90px; text-align: center;}

--- a/css/xapi.css
+++ b/css/xapi.css
@@ -4,12 +4,20 @@ h1#title {
 	margin:2px;
 }
 #bboxmap {
-    width: 512px;
-    height: 256px;
+    width:100%;
+    height:100%;
     margin: 0;
+}
+#bboxmap_outer {
+    padding:6px;
+    width: 542px;
+    height: 240px;
+    overflow: auto;
+    resize: both;
     border: solid 1px #ddd;
     background-color:#eee;
 }
+
 
 .filter_box_content {
 	background-color:#eaf5ea;

--- a/js/xapi.js
+++ b/js/xapi.js
@@ -11,6 +11,8 @@ $(document).ready(function() {
   map = new OpenLayers.Map('bboxmap', 
                            {projection: "EPSG:900913",});
 
+  map.addControl(new OpenLayers.Control.Attribution());
+    
   // We'll use these projections in our functions later
   var goog =  new OpenLayers.Projection("EPSG:900913");
   var latlon = new OpenLayers.Projection("EPSG:4326");
@@ -275,13 +277,13 @@ $(document).ready(function() {
     document.title = json.title;
     $('#title').text(json.title);
 
-    var maps = json.map;
+    var maps = json.map; //get the set of configured map layers from config.json
     var count_maps = 0;
     $.each(maps, function(index, amap) {
       map.addLayer(new OpenLayers.Layer.OSM(amap.name,
-        amap.tiles + "${z}/${x}/${y}.png", {atribution:''}));
+        amap.tiles + "${z}/${x}/${y}.png", {attribution: amap.attribution }));
       count_maps++;
-      $('#attribution').append('<b>'+amap.name+':</b> '+amap.attribution+'<br />');
+      //$('#attribution').append('<b>'+amap.name+':</b> '+amap.attribution+'<br />');
     });
     if (count_maps>1) {
       map.addControl(new OpenLayers.Control.LayerSwitcher());

--- a/sample-config.json
+++ b/sample-config.json
@@ -1,15 +1,20 @@
-{ "title": "My XAPI Server Frontend",
+{ "title": "XAPI URL builder",
   "baseurl": "http://newbaseurl.com",
   "map": [
     {
       "name": "MapQuest",
       "tiles": "http://otile1.mqcdn.com/tiles/1.0.0/osm/",
-      "attribution": "Data, imagery and map information provided by MapQuest, <a href='<http://www.openstreetmap.org/'>Open Street Map</a> and contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
+      "attribution": "<a href='<http://www.openstreetmap.org/'>OpenStreetMap</a> and contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a> Tiles Courtesy of <a href='http://www.mapquest.com/' target='_blank'>MapQuest</a> <img src='http://developer.mapquest.com/content/osm/mq_logo.png'>"
     },
     {
-      "name": "OpenStreetMap",
-      "tiles": "http://a.tile.openstreetmap.org/",
-      "attribution": "Data <a href='<http://www.openstreetmap.org/'>Open Street Map</a> and contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
+      "name": "OSM mapnik",
+      "tiles": "http://tile.openstreetmap.org/",
+      "attribution": "Data <a href='<http://www.openstreetmap.org/'>OpenStreetMap</a> and contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
+    },
+    {
+      "name": "OSM tile@home",
+      "tiles": "http://tah.openstreetmap.org/Tiles/tile/",
+      "attribution": "Data <a href='<http://www.openstreetmap.org/'>OpenStreetMap</a> and contributors, <a href='http://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>"
     }
   ]
 }

--- a/xapi.html
+++ b/xapi.html
@@ -58,7 +58,9 @@
             <label for="bboxToggle">select area</label>
           </div>
           
-          <div id="bboxmap"></div>
+          <div id="bboxmap_outer">
+            <div id="bboxmap"></div>
+          </div>
           <!--<div id="attribution"></div>-->
           
           <div id="bbox">

--- a/xapi.html
+++ b/xapi.html
@@ -22,14 +22,16 @@
   </head>
   
   <body>
-    <div id="title">
+    <h1 id="title">
       XAPI Selector
-    </div>
+    </h1>
     <div id="xapiselector">
       <div id="search_by_tags">
-        <input type="checkbox" id="searchbytag" checked="checked" />
-        <label for="searchbytag">Search by Tag</label>
-        <div id="search_by_tags_elements">
+        <div class="filter_box_top">
+           <input type="checkbox" id="searchbytag" checked="checked" />
+           <label for="searchbytag">Search by Tag</label>
+        </div>
+        <div class="filter_box_content">
           <select id="element">
             <option value="*" selected="selected">Any</option>
             <option value="node">Nodes</option>
@@ -42,43 +44,47 @@
       </div>
 
       <div id="search_by_bbox">
-        <input type="checkbox" id="searchbybbox" />
-        <label for="searchbybbox">Search by Area</label>
-
-        <div id="mapcontrol">
-          <input type="radio" name="type" id="bboxNone" checked="checked" disabled="yes" />
-          <label for="bboxNone">navigate</label>
-
-          <input type="radio" name="type" id="bboxToggle" disabled="yes" />
-          <label for="bboxToggle">select area</label>
+        <div class="filter_box_top">
+          <input type="checkbox" id="searchbybbox" />
+          <label for="searchbybbox">Search by Area</label>
         </div>
-
-        <div id="bboxmap"></div>
-        <div id="attribution"></div>
-
-        <div id="bbox">
-        <div id="b_left" class="bounds">
-            <label for="bbox_left" class="bbox">left:</label>
-            <input type="text" id="bbox_left" class="bbox" maxlength="10" value="-180.00000" disabled="yes" />
+        <div class="filter_box_content">
+          
+          <div id="mapcontrol">
+            <input type="radio" name="type" id="bboxNone" checked="checked" disabled="yes" />
+            <label for="bboxNone">navigate</label>
+          
+            <input type="radio" name="type" id="bboxToggle" disabled="yes" />
+            <label for="bboxToggle">select area</label>
           </div>
-          <div id="b_bottom" class="bounds">
-            <label for="bbox_bottom" class="bbox">bottom:</label>
-            <input type="text" id="bbox_bottom" class="bbox" maxlength="10" value="-90.00000" disabled="yes" />
-          </div>
-          <div id="b_right" class="bounds">
-            <label for="bbox_right" class="bbox">right:</label>
-            <input type="text" id="bbox_right" class="bbox" maxlength="10" value="180.00000" disabled="yes" />
-          </div>
-          <div id="b_top" class="bounds">
-            <label for="bbox_top" class="bbox">top:</label>
-            <input type="text" id="bbox_top" class="bbox" maxlength="10" value="90.00000" disabled="yes" />
+          
+          <div id="bboxmap"></div>
+          <!--<div id="attribution"></div>-->
+          
+          <div id="bbox">
+          <div id="b_left" class="bounds">
+              <label for="bbox_left" class="bbox">left:</label>
+              <input type="text" id="bbox_left" class="bbox" maxlength="10" value="-180.00000" disabled="yes" />
+            </div>
+            <div id="b_bottom" class="bounds">
+              <label for="bbox_bottom" class="bbox">bottom:</label>
+              <input type="text" id="bbox_bottom" class="bbox" maxlength="10" value="-90.00000" disabled="yes" />
+            </div>
+            <div id="b_right" class="bounds">
+              <label for="bbox_right" class="bbox">right:</label>
+              <input type="text" id="bbox_right" class="bbox" maxlength="10" value="180.00000" disabled="yes" />
+            </div>
+            <div id="b_top" class="bounds">
+              <label for="bbox_top" class="bbox">top:</label>
+              <input type="text" id="bbox_top" class="bbox" maxlength="10" value="90.00000" disabled="yes" />
+            </div>
           </div>
         </div>
       </div>
 
       <div id="xapiurl">
-        Results:
-        <a id="results" href="">URL Here</a>
+        Your XAPI URL:
+        <span id="results_outer"><a id="results" href="">URL Here</a><span>
       </div>
     </div>
   </body>


### PR DESCRIPTION
Some cosmetic changes.

Also I changed the attribution mechanism back to the built-in OpenLayers one.  I suspect maybe you'd tried to do it that way before, but you'd spelt 'attribution' 'atribution' so it hadn't been working for you. All looks good now. 

See it running here: http://harrywood.dev.openstreetmap.org/uixapi/xapi-ui/xapi.html
